### PR TITLE
Add UNet Networking Code

### DIFF
--- a/Assets/Networking.meta
+++ b/Assets/Networking.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: eec2562420c09a648a3c181c169640e2
+folderAsset: yes
+timeCreated: 1531164276
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Networking/unet.meta
+++ b/Assets/Networking/unet.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 72d3c3a7ee6f4a142b7d5134995713a4
+folderAsset: yes
+timeCreated: 1531164282
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Networking/unet/DebugHUD.cs
+++ b/Assets/Networking/unet/DebugHUD.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+using System.Linq;
+
+public class DebugHUD : MonoBehaviour
+{
+    private Vector2 dataWindowScrollPos = Vector2.zero;
+
+    private const int dataScrollHeight = 300;
+    private const int width = 150;
+
+    protected void OnGUI()
+    {
+        ServerGUI();
+
+        DataGUI();
+
+        ClientGUI();
+    }
+
+    private static void ServerGUI()
+    {
+        if (UnetGameplayServer.Instance.isServer)
+        {
+            GUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(width));
+            GUILayout.Label("SERVER:");
+
+            GUI.enabled = !UnetGameplayServer.Instance.GameStarted;
+            if (GUILayout.Button("Start Game"))
+            {
+                UnetGameplayServer.Instance.StartGame();
+            }
+
+            GUI.enabled = true;
+            GUILayout.Label(string.Format("Players: {0}", UnetGameplayServer.Instance.GameStarted ? UnetGameplayServer.Instance.PlayerCount : NetworkServer.connections.Count(x => x != null)));
+            GUILayout.Label(string.Format("Current Round: {0}", UnetGameplayServer.Instance.CurrentRound));
+            GUILayout.Label(string.Format("Posted Player Moves: {0}", UnetGameplayServer.Instance.PostedPlayerMoves));
+            GUILayout.HorizontalSlider(UnetGameplayServer.Instance.PostedPlayerMoves, 0, UnetGameplayServer.Instance.PlayerCount);
+
+            GUI.enabled = UnetGameplayServer.Instance.GameStarted;
+            if (GUILayout.Button("Publish Round"))
+            {
+                UnetGameplayServer.Instance.PublishRound();
+            }
+
+            GUILayout.EndVertical();
+        }
+    }
+
+    private void DataGUI()
+    {
+        if (UnetGameplayServer.Instance.GameStarted)
+        {
+            GUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(width));
+            GUILayout.Label("DATA:");
+
+            dataWindowScrollPos = GUILayout.BeginScrollView(dataWindowScrollPos, GUILayout.MaxHeight(300), GUILayout.MinHeight(0));
+
+            for (int i = 0; i < UnetGameplayServer.Instance.Moves.Count; i++)
+            {
+                GUILayout.Label(string.Format("Move {0}", i));
+
+                if (UnetGameplayServer.Instance.Moves[i] == null)
+                {
+                    GUILayout.Label("\t MISSING");
+                    continue;
+                }
+
+                for (int j = 0; j < UnetGameplayServer.Instance.Moves[i].Length; j++)
+                {
+                    GUILayout.Label(string.Format("  {0} - {1}", j, UnetGameplayServer.Instance.Moves[i][j]));
+                }
+            }
+
+            if (UnetGameplayServer.Instance.isServer)
+            {
+                GUILayout.Label("Pre Published Data");
+                for (int j = 0; j < UnetGameplayServer.Instance.PrePublishedData.Length; j++)
+                {
+                    GUILayout.Label(string.Format("  {0} - {1}", j, UnetGameplayServer.Instance.PrePublishedData[j]));
+                }
+            }
+
+            GUILayout.EndScrollView();
+
+            GUILayout.EndVertical();
+        }
+    }
+
+    private string moveString;
+    private void ClientGUI()
+    {
+        if (UnetGameplayServer.Instance.isClient && UnetPlayerPrefab.LocalPlayer != null)
+        {
+            GUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(width));
+            GUILayout.Label("CLIENT:");
+
+            GUILayout.Label(string.Format("Player ID: {0}", UnetPlayerPrefab.LocalPlayer.PlayerID));
+
+            GUI.enabled = UnetGameplayServer.Instance.GameStarted;
+
+            GUILayout.Label("Move:");
+            moveString = GUILayout.TextField(moveString);
+
+            if (GUILayout.Button("Post Move"))
+            {
+                UnetPlayerPrefab.LocalPlayer.CmdPostMove(UnetGameplayServer.Instance.CurrentRound, moveString);
+                moveString = "";
+            }
+
+            GUILayout.EndVertical();
+        }
+    }
+}

--- a/Assets/Networking/unet/DebugHUD.cs.meta
+++ b/Assets/Networking/unet/DebugHUD.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 04ac77566c119f34ab01e3edbb6bb981
+timeCreated: 1531164458
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Networking/unet/DebugHUD.prefab
+++ b/Assets/Networking/unet/DebugHUD.prefab
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1134372286361164}
+  m_IsPrefabParent: 1
+--- !u!1 &1134372286361164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4903721995727414}
+  - component: {fileID: 114591300485597712}
+  m_Layer: 0
+  m_Name: DebugHUD
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4903721995727414
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1134372286361164}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114591300485597712
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1134372286361164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04ac77566c119f34ab01e3edbb6bb981, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Networking/unet/DebugHUD.prefab.meta
+++ b/Assets/Networking/unet/DebugHUD.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: da20ab9f1dce5034d9f87d84472ba97c
+timeCreated: 1531164469
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Networking/unet/UnetGameplayServer.cs
+++ b/Assets/Networking/unet/UnetGameplayServer.cs
@@ -1,0 +1,133 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class UnetGameplayServer : NetworkBehaviour
+{
+#if UNITY_EDITOR
+    [UnityEditor.CustomEditor(typeof(UnetGameplayServer))]
+    public class Editor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            UnetGameplayServer t = (UnetGameplayServer)target;
+
+            GUI.enabled = Application.isPlaying && !t.gameStarted;
+            if (GUILayout.Button("Start Game"))
+            {
+                t.StartGame();
+            }
+
+            GUI.enabled = Application.isPlaying && t.gameStarted;
+            if (GUILayout.Button("Publish Round"))
+            {
+                t.PublishRound();
+            }
+
+            GUI.enabled = false;
+            UnityEditor.EditorGUILayout.IntField("Current Rount", t.currentRound);
+            UnityEditor.EditorGUILayout.IntField("Player Count", t.playerCount);
+
+            UnityEditor.EditorGUILayout.IntSlider("Posted Player Moves", t.PostedPlayerMoves, 0, t.playerCount);
+
+        }
+    }
+#endif
+
+    public static UnetGameplayServer Instance;
+
+    private List<string[]> moves;
+    public List<string[]> Moves { get { return moves; } }
+
+    private string[] prePublishedData = null;
+    public string[] PrePublishedData { get { return prePublishedData; } }
+
+    [SyncVar]
+    private int currentRound;
+    public int CurrentRound { get { return currentRound; } }
+
+    [SyncVar]
+    private int playerCount;
+    public int PlayerCount { get { return playerCount; } }
+
+    [SyncVar]
+    private bool gameStarted;
+    public bool GameStarted { get { return gameStarted; } }
+
+    public int PostedPlayerMoves { get { return gameStarted ? PrePublishedData.Count(x => !string.IsNullOrEmpty(x)) : 0; } }
+
+    protected void Awake()
+    {
+        Instance = this;
+    }
+
+    protected void OnEnable()
+    {
+        moves = new List<string[]>();
+        currentRound = 0;
+        playerCount = 0;
+        gameStarted = false;
+    }
+
+    public void StartGame()
+    {
+        Debug.Assert(isServer, "Must Run on Server");
+
+        var players = NetworkServer.connections.Where(x => x != null).ToArray();
+        playerCount = players.Length;
+
+        for (int i = 0; i < playerCount; i++)
+        {
+            players[i].playerControllers[0].gameObject.GetComponent<UnetPlayerPrefab>().PlayerID = i;
+        }
+
+        prePublishedData = new string[playerCount];
+        gameStarted = true;
+    }
+
+    public void PostPlayerMove(int player, int round, string move)
+    {
+        Debug.Assert(isServer, "Must Run on Server");
+
+        if (round != currentRound
+            || player >= playerCount
+            || !gameStarted)
+        {
+            Debug.LogWarning("Incorrect data.  Ignoring");
+            return;
+        }
+
+        prePublishedData[player] = move;
+        Debug.LogFormat("Got move data for round {0}, player {1}", round, player);
+    }
+
+    public void PublishRound()
+    {
+        RpcPublishRoundData(currentRound, prePublishedData);
+
+        currentRound++;
+
+        prePublishedData = new string[playerCount];
+    }
+
+    [ClientRpc]
+    protected void RpcPublishRoundData(int round, string[] moveData)
+    {
+        Debug.Assert(isClient, "Must Run on Client");
+        Debug.LogFormat("Got round data for round {0}", round);
+
+        // Pad empty moves for missing data
+        for (int i = moves.Count; i <= round; i++)
+        {
+            moves.Add(null);
+        }
+
+        // Set data
+        moves[round] = moveData;
+    }
+
+}

--- a/Assets/Networking/unet/UnetGameplayServer.cs.meta
+++ b/Assets/Networking/unet/UnetGameplayServer.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: a6ebd92aec40fde4a8392dc609399544
+timeCreated: 1530991662
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Networking/unet/UnetGameplayServer.prefab
+++ b/Assets/Networking/unet/UnetGameplayServer.prefab
@@ -1,0 +1,104 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1695288866455302}
+  m_IsPrefabParent: 1
+--- !u!1 &1695288866455302
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4936481253195064}
+  - component: {fileID: 114732339529678556}
+  - component: {fileID: 114073423637997824}
+  m_Layer: 0
+  m_Name: UnetGameplayServer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4936481253195064
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1695288866455302}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114073423637997824
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1695288866455302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6ebd92aec40fde4a8392dc609399544, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SyncVarDirtyBits: 0
+  m_LastSendTime: 0
+  m_SyncVarGuard: 0
+  m_MyView: {fileID: 0}
+  currentRound: 0
+  playerCount: 0
+  gameStarted: 0
+  serverWindowRect:
+    x: 250
+    y: 0
+    width: 200
+    height: 0
+  dataWindowRect:
+    x: 250
+    y: 300
+    width: 200
+    height: 200
+  dataWindowScrollPos: {x: 0, y: 0}
+--- !u!114 &114732339529678556
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1695288866455302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 372142912, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SceneId:
+    m_Value: 0
+  m_AssetId:
+    i0: 139
+    i1: 33
+    i2: 245
+    i3: 178
+    i4: 77
+    i5: 46
+    i6: 149
+    i7: 164
+    i8: 155
+    i9: 201
+    i10: 253
+    i11: 62
+    i12: 25
+    i13: 196
+    i14: 167
+    i15: 76
+  m_ServerOnly: 0
+  m_LocalPlayerAuthority: 0

--- a/Assets/Networking/unet/UnetGameplayServer.prefab.meta
+++ b/Assets/Networking/unet/UnetGameplayServer.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 8b21f5b24d2e95a49bc9fd3e19c4a74c
+timeCreated: 1530997644
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Networking/unet/UnetManager.prefab
+++ b/Assets/Networking/unet/UnetManager.prefab
@@ -1,0 +1,140 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1236028815351436}
+  m_IsPrefabParent: 1
+--- !u!1 &1236028815351436
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4121261974486856}
+  - component: {fileID: 114415904805597356}
+  - component: {fileID: 114059692255864202}
+  m_Layer: 0
+  m_Name: UnetManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4121261974486856
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1236028815351436}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114059692255864202
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1236028815351436}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 227461547, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  manager: {fileID: 0}
+  showGUI: 1
+  offsetX: 150
+  offsetY: -30
+--- !u!114 &114415904805597356
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1236028815351436}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -822479833, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_NetworkPort: 7777
+  m_ServerBindToIP: 0
+  m_ServerBindAddress: 
+  m_NetworkAddress: localhost
+  m_DontDestroyOnLoad: 0
+  m_RunInBackground: 1
+  m_ScriptCRCCheck: 1
+  m_MaxDelay: 0.01
+  m_LogLevel: 2
+  m_PlayerPrefab: {fileID: 1009339237645336, guid: 6b43e20608d7d0d468fc172ed17b79d0,
+    type: 2}
+  m_AutoCreatePlayer: 1
+  m_PlayerSpawnMethod: 0
+  m_OfflineScene: 
+  m_OnlineScene: 
+  m_SpawnPrefabs: []
+  m_CustomConfig: 0
+  m_MaxConnections: 4
+  m_ConnectionConfig:
+    m_PacketSize: 1440
+    m_FragmentSize: 500
+    m_ResendTimeout: 1200
+    m_DisconnectTimeout: 2000
+    m_ConnectTimeout: 2000
+    m_MinUpdateTimeout: 10
+    m_PingTimeout: 500
+    m_ReducedPingTimeout: 100
+    m_AllCostTimeout: 20
+    m_NetworkDropThreshold: 5
+    m_OverflowDropThreshold: 5
+    m_MaxConnectionAttempt: 10
+    m_AckDelay: 33
+    m_SendDelay: 10
+    m_MaxCombinedReliableMessageSize: 100
+    m_MaxCombinedReliableMessageCount: 10
+    m_MaxSentMessageQueueSize: 512
+    m_AcksType: 1
+    m_UsePlatformSpecificProtocols: 0
+    m_InitialBandwidth: 0
+    m_BandwidthPeakFactor: 2
+    m_WebSocketReceiveBufferMaxSize: 0
+    m_UdpSocketReceiveBufferMaxSize: 0
+    m_SSLCertFilePath: 
+    m_SSLPrivateKeyFilePath: 
+    m_SSLCAFilePath: 
+    m_Channels: []
+  m_GlobalConfig:
+    m_ThreadAwakeTimeout: 1
+    m_ReactorModel: 0
+    m_ReactorMaximumReceivedMessages: 1024
+    m_ReactorMaximumSentMessages: 1024
+    m_MaxPacketSize: 2000
+    m_MaxHosts: 16
+    m_ThreadPoolSize: 1
+    m_MinTimerTimeout: 1
+    m_MaxTimerTimeout: 12000
+    m_MinNetSimulatorTimeout: 1
+    m_MaxNetSimulatorTimeout: 12000
+  m_Channels: 
+  m_UseWebSockets: 0
+  m_UseSimulator: 0
+  m_SimulatedLatency: 1
+  m_PacketLossPercentage: 0
+  m_MaxBufferedPackets: 16
+  m_AllowFragmentation: 1
+  m_MatchHost: mm.unet.unity3d.com
+  m_MatchPort: 443
+  matchName: default
+  matchSize: 100
+  isNetworkActive: 0
+  matchMaker: {fileID: 0}

--- a/Assets/Networking/unet/UnetManager.prefab.meta
+++ b/Assets/Networking/unet/UnetManager.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 8fdd53487efd3844db0fb15f73ebdcf2
+timeCreated: 1530991514
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Networking/unet/UnetPlayerPrefab.cs
+++ b/Assets/Networking/unet/UnetPlayerPrefab.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class UnetPlayerPrefab : NetworkBehaviour
+{
+    public static UnetPlayerPrefab LocalPlayer { get; private set; }
+
+    [SyncVar]
+    private int playerID = -1;
+    public int PlayerID { get { return playerID; } set { Debug.Assert(isServer); playerID = value; } }
+
+    protected void Start()
+    {
+        if (hasAuthority)
+        {
+            LocalPlayer = this;
+        }
+    }
+
+    [Command]
+    public void CmdPostMove(int round, string move)
+    {
+        Debug.Assert(isServer, "Must Run on Server");
+
+        UnetGameplayServer.Instance.PostPlayerMove(playerID, round, move);
+    }
+}

--- a/Assets/Networking/unet/UnetPlayerPrefab.cs.meta
+++ b/Assets/Networking/unet/UnetPlayerPrefab.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 4e3f99dcbfb8961409e9ab8af3266d21
+timeCreated: 1530991610
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Networking/unet/UnetPlayerPrefab.prefab
+++ b/Assets/Networking/unet/UnetPlayerPrefab.prefab
@@ -1,0 +1,97 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1009339237645336}
+  m_IsPrefabParent: 1
+--- !u!1 &1009339237645336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4764802058351674}
+  - component: {fileID: 114409966783800746}
+  - component: {fileID: 114822495617783728}
+  m_Layer: 0
+  m_Name: UnetPlayerPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4764802058351674
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1009339237645336}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114409966783800746
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1009339237645336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 372142912, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SceneId:
+    m_Value: 0
+  m_AssetId:
+    i0: 107
+    i1: 67
+    i2: 226
+    i3: 6
+    i4: 8
+    i5: 215
+    i6: 208
+    i7: 212
+    i8: 104
+    i9: 252
+    i10: 23
+    i11: 46
+    i12: 209
+    i13: 123
+    i14: 121
+    i15: 208
+  m_ServerOnly: 0
+  m_LocalPlayerAuthority: 1
+--- !u!114 &114822495617783728
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1009339237645336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e3f99dcbfb8961409e9ab8af3266d21, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SyncVarDirtyBits: 0
+  m_LastSendTime: 0
+  m_SyncVarGuard: 0
+  m_MyView: {fileID: 0}
+  playerID: -1
+  guiMove: 
+  windowRect:
+    x: 500
+    y: 0
+    width: 200
+    height: 0

--- a/Assets/Networking/unet/UnetPlayerPrefab.prefab.meta
+++ b/Assets/Networking/unet/UnetPlayerPrefab.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6b43e20608d7d0d468fc172ed17b79d0
+timeCreated: 1530991536
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I added four prefabs
- UnetManager
  - This handles the actual UNet networking stuff.  Its all stuff from unity, so nothing new here
- UnetGameplayServer
  - This is where the data gets stored for the moves, and where the data gets published from the server to the clients
- DebugHUD
  - You would remove this and replace the functionality with actual in game logic
- UnetPlayerPrefab
  - Every 'client' in the networking session has a 'player' object.  This is because of unet weirdness, but its the portal through which the client can talk to the server

I can show you how all this works tomorrow :)